### PR TITLE
The path for nftDetails' CodeUri should ./lambda/nftdetails instead o…

### DIFF
--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -160,7 +160,7 @@ Resources:
          networkId: !GetAtt EthereumNode.NetworkId
       Handler: index.handler
       Runtime: nodejs14.x
-      CodeUri: lambdas/nftDetails/.
+      CodeUri: lambdas/nftdetails/.
       Description: Call the AWS Lambda API for NFT Details
       Timeout: 30
       Policies:


### PR DESCRIPTION
…f ./lambda/nftDetails

Incorrect path will cause deploy error. Following is the error message:

Error: Unable to upload artifact nftDetails referenced by CodeUri parameter of nftDetails resource. Parameter CodeUri of resource nftDetails refers to a file or folder that does not exist /home/ubuntu/environment/nft-access-control-lambda-authorizer/serverless/.aws-sam/build/nftDetails

*Issue #, if available:*
31
*Description of changes:*
Fix typo in serverless/template.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
